### PR TITLE
Fix to docker-compose up -d build

### DIFF
--- a/task/Dockerfile
+++ b/task/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.10
+FROM ubuntu:trusty
 MAINTAINER Uluc Aydin "hi@ulucaydin.com"
 
 # install dependencies

--- a/task/Dockerfile
+++ b/task/Dockerfile
@@ -13,7 +13,7 @@ ADD . /code/
 RUN pip install -r /code/requirements.txt
 
 # Set celery_user and give privilidges
-RUN adduser celery_user --disabled-password &&\
+RUN useradd celery_user -ms /bin/bash &&\
     chown -R celery_user:celery_user /code &&\
     chmod 755 /code/*
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.10
+FROM ubuntu:trusty
 MAINTAINER Uluc Aydin "hi@ulucaydin.com"
 
 # install dependencies


### PR DESCRIPTION
- Resolves errors that occur while building the docker images because ubuntu:14.10 is no longer maintained, so the docker images fail to build properly as in #1
- Also change to useradd to avoid awkward prompting for name and office on user creation.
